### PR TITLE
fix: Use c++11 compatible map for loop

### DIFF
--- a/src/nemo-feedback/NemoFeedbackWriter.cc
+++ b/src/nemo-feedback/NemoFeedbackWriter.cc
@@ -87,11 +87,12 @@ void NemoFeedbackWriter::define_coord_variables(const size_t n_obs,
     const size_t n_levels, const size_t n_obs_vars,
     const size_t n_add_entries) {
   netCDF::NcDim tmp_Dim;
-  for (const auto& [key, value] : coord_sizes) {
-    if (key == N_QCF) {
-      nqcf_dim = std::make_unique<netCDF::NcDim>(ncFile->addDim(key, value));
+  for (const auto& kv : coord_sizes) {
+    if (kv.first == N_QCF) {
+      nqcf_dim = std::make_unique<netCDF::NcDim>(
+          ncFile->addDim(kv.first, kv.second));
     } else {
-      tmp_Dim = ncFile->addDim(key, value);
+      tmp_Dim = ncFile->addDim(kv.first, kv.second);
     }
   }
 


### PR DESCRIPTION
## Summary of Changes

This is a small change to the loop syntax in a loop over a `std::map` to use only C++11 compatible features. See [Stack Overflow](https://stackoverflow.com/a/6963910) for a discussion of the different loop styles available at different versions of the standard.

## Issues

* Fixes #1 