### PR TITLE
fix: support for writing two variables

### DIFF
--- a/src/nemo-feedback/NemoFeedback.cc
+++ b/src/nemo-feedback/NemoFeedback.cc
@@ -270,20 +270,23 @@ void NemoFeedback::postFilter(const ufo::GeoVaLs & gv,
           std::vector<std::string> ov_varnames = ov.varnames().variables();
           auto var_it = std::find(ov_varnames.begin(), ov_varnames.end(),
               ufo_name);
-          oops::Log::trace() << "ov_varnames = " << ov_varnames << std::endl;
+          oops::Log::trace() << "NemoFeedback::ov_varnames = "
+                             << ov_varnames << std::endl;
           std::size_t var_it_dist = static_cast<std::size_t>(
                                     std::distance(ov_varnames.begin(), var_it));
-          oops::Log::trace() << "iterator distance is "
+          oops::Log::trace() << "NemoFeedback::iterator distance is "
                              << var_it_dist
+                             << " ov.nvars: " << ov.nvars()
                              << std::endl;
-          auto missing_value_add = util::missingValue(ov[var_it_dist * n_obs]);
-          oops::Log::trace() << "Missing value: " << missing_value_add
+          const auto missing_value_add = util::missingValue(ov[var_it_dist]);
+          oops::Log::trace() << "NemoFeedback::Missing value: " << missing_value_add
               << std::endl;
           for (int i=0; i < n_obs; ++i) {
-            if (ov[i+(var_it_dist * n_obs)] == missing_value_add) {
+            const size_t indx = i * ov.nvars() + var_it_dist;
+            if (ov[indx] == missing_value_add) {
               variable_data[i] = NemoFeedbackWriter::double_fillvalue;
             } else {
-              variable_data[i] = ov[i+(var_it_dist * n_obs)];
+              variable_data[i] = ov[indx];
             }
           }
           fdbk_writer.write_variable_surf(

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -3,12 +3,22 @@ add_subdirectory(testoutput)
 add_subdirectory(nemo-feedback)
 add_subdirectory(mains)
 
-ecbuild_add_test( TARGET test_orcamodel_hofx_feedback_writer
+ecbuild_add_test( TARGET test_orcamodel_hofx_ice_writer
                   OMP 1
                   ARGS testinput/seaice_obs_writer.yaml
                   COMMAND orcamodel_hofx.x )
 
-ecbuild_add_test( TARGET test_orcamodel_hofx_feedback_file
+ecbuild_add_test( TARGET test_orcamodel_hofx_ice_file
                   OMP 1
                   ARGS testoutput/test_hofx_feedback_writer_out.nc testoutput/test_hofx_feedback_writer_out_ref.cdl
+                  COMMAND ./mains/compare_nc_cdl.sh )
+
+ecbuild_add_test( TARGET test_orcamodel_hofx_two_vars_writer
+                  OMP 1
+                  ARGS testinput/hofx_two_vars_writer.yaml
+                  COMMAND orcamodel_hofx.x )
+
+ecbuild_add_test( TARGET test_orcamodel_hofx_two_vars_file
+                  OMP 1
+                  ARGS testoutput/test_hofx_two_vars_writer_out.nc testoutput/test_hofx_two_vars_writer_out_ref.cdl
                   COMMAND ./mains/compare_nc_cdl.sh )

--- a/src/tests/testinput/CMakeLists.txt
+++ b/src/tests/testinput/CMakeLists.txt
@@ -1,6 +1,7 @@
 
 list( APPEND fdbk_writer_test_input
   seaice_obs_writer.yaml
+  hofx_two_vars_writer.yaml
 )
 
 foreach(FILENAME ${fdbk_writer_test_input})

--- a/src/tests/testinput/hofx_two_vars_writer.yaml
+++ b/src/tests/testinput/hofx_two_vars_writer.yaml
@@ -1,0 +1,94 @@
+forecast length : P3D
+geometry :
+  nemo variables:
+    - name: ice_area_fraction
+      nemo field name: iiceconc
+      type: surface
+    - name: sea_surface_temperature
+      nemo field name: votemper
+      type: surface
+    - name: sea_water_potential_temperature
+      nemo field name: votemper
+      type: volume
+    - name: ice_area_fraction_background_error
+      nemo field name: sic_tot_var
+      type: surface
+    - name: sea_surface_temperature_background_error
+      nemo field name: t_tot_var
+      type: surface
+  grid name: ORCA2_T
+  number levels: 10
+  variance names: [ ice_area_fraction_background_error, sea_surface_temperature_background_error ]
+initial condition :
+  date: 2021-06-29T21:00:00Z
+  state variables: [ ice_area_fraction, sea_surface_temperature, ice_area_fraction_background_error, sea_surface_temperature_background_error ]
+  nemo field file: ../../../orca-jedi/src/tests/Data/orca2_t_nemo.nc
+  variance field file: ../../../orca-jedi/src/tests/Data/orca2_t_bkg_var.nc
+model :
+  name: PseudoModel
+  tstep: P3D
+  state variables: [ ice_area_fraction, sea_surface_temperature ]
+  states:
+    - date: 2021-06-29T21:00:00Z
+      nemo field file: ../../../orca-jedi/src/tests/Data/orca2_t_nemo.nc
+      variance field file: ../../../orca-jedi/src/tests/Data/orca2_t_bkg_var.nc
+      state variables: [ ice_area_fraction, sea_surface_temperature ]
+window begin: 2021-06-29T21:00:00Z
+window length: P1D
+observations:
+- obs space:
+    name: Sea Ice
+    obsdatain:
+      obsfile: ../../../orca-jedi/src/tests/Data/hofx_two_vars_obs.nc
+      max frame size: 1000000
+    obsdataout:
+      obsfile: test_out.nc
+      max frame size: 1000000
+    simulated variables: [ice_area_fraction, sea_surface_temperature]
+  get values:
+    atlas-interpolator:
+      type: bilinear-remapping
+      non_linear: missing-if-all-missing
+      max_fraction_elems_to_try: 0.0
+  obs operator:
+    name: Composite
+    components:
+    - name: Identity
+    - name: BackgroundErrorIdentity
+  obs filters:
+  - filter: Create Diagnostic Flags
+    flags:
+    - name: FinalReject
+      initial value: false
+  - filter: Bayesian Background Check
+    defer to post: true
+    filter variables:
+    - name: ice_area_fraction
+    prob density bad obs: 1.0
+    initial prob gross error: 0.04
+    PGE threshold: 0.5
+    actions:
+    - name: set
+      flag: FinalReject
+    - name: reject
+  - filter: NEMO Feedback Writer
+    filename: testoutput/test_hofx_two_vars_writer_out.nc
+    variables:
+    - name: ice_area_fraction
+      nemo name: ICECONC
+      long name: ice area fraction
+      units: Fraction
+      additional variables:
+      - name: ice_area_fraction
+        feedback suffix: Hx
+        ioda group: HofX
+    - name: sea_surface_temperature
+      nemo name: SST
+      long name: sea_surface_temperature
+      units: Fraction
+      additional variables:
+      - name: sea_surface_temperature
+        feedback suffix: Hx
+        ioda group: HofX
+test:
+  reference filename: testoutput/test_hofx_two_vars_writer.ref

--- a/src/tests/testoutput/CMakeLists.txt
+++ b/src/tests/testoutput/CMakeLists.txt
@@ -2,6 +2,8 @@
 list( APPEND fdbk_writer_test_output
   test_hofx_feedback_writer.ref
   test_hofx_feedback_writer_out_ref.cdl
+  test_hofx_two_vars_writer.ref
+  test_hofx_two_vars_writer_out_ref.cdl
 )
 
 foreach(FILENAME ${fdbk_writer_test_output})

--- a/src/tests/testoutput/test_hofx_two_vars_writer.ref
+++ b/src/tests/testoutput/test_hofx_two_vars_writer.ref
@@ -1,0 +1,23 @@
+Test     : Initial state: 
+Test     :  Model state valid at time: 2021-06-29T21:00:00Z
+Test     :     4 variables: ice_area_fraction, sea_surface_temperature, ice_area_fraction_background_error, sea_surface_temperature_background_error
+Test     :     atlas field norms:
+Test     :         ice_area_fraction: 0.00323467
+Test     :         sea_surface_temperature: 0.136432
+Test     :         ice_area_fraction_background_error: 0.00303628
+Test     :         sea_surface_temperature_background_error: 0.000607255
+
+Test     : Final state: 
+Test     :  Model state valid at time: 2021-07-02T21:00:00Z
+Test     :     4 variables: ice_area_fraction, sea_surface_temperature, ice_area_fraction_background_error, sea_surface_temperature_background_error
+Test     :     atlas field norms:
+Test     :         ice_area_fraction: 0.00323467
+Test     :         sea_surface_temperature: 0.136432
+Test     :         ice_area_fraction_background_error: 0.00303628
+Test     :         sea_surface_temperature_background_error: 0.000607255
+
+Test     : H(x): 
+Test     : Sea Ice nobs= 14 Min=0, Max=18.1724, RMS=12.6338
+
+Test     : End H(x)
+

--- a/src/tests/testoutput/test_hofx_two_vars_writer_out_ref.cdl
+++ b/src/tests/testoutput/test_hofx_two_vars_writer_out_ref.cdl
@@ -1,0 +1,411 @@
+netcdf test_hofx_two_vars_writer_out {
+dimensions:
+	N_QCF = 2 ;
+	STRINGGRID = 1 ;
+	STRINGJULD = 14 ;
+	STRINGNAM = 8 ;
+	STRINGTYP = 4 ;
+	STRINGWMO = 8 ;
+	N_OBS = 11 ;
+	N_LEVELS = 1 ;
+	N_VARS = 2 ;
+	N_ENTRIES = 1 ;
+variables:
+	char JULD_REFERENCE(STRINGJULD) ;
+		JULD_REFERENCE:long_name = "Date of reference for julian days" ;
+		JULD_REFERENCE:Conventions = "YYYYMMDDHHMMSS" ;
+	char VARIABLES(N_VARS, STRINGNAM) ;
+		VARIABLES:long_name = "List of variables in feedback files" ;
+	char ENTRIES(N_ENTRIES, STRINGNAM) ;
+		ENTRIES:long_name = "List of additional entries for each variable in feedback files" ;
+	double LATITUDE(N_OBS) ;
+		LATITUDE:units = "degrees_north" ;
+		LATITUDE:long_name = "latitude" ;
+	double LONGITUDE(N_OBS) ;
+		LONGITUDE:units = "degrees_east" ;
+		LONGITUDE:long_name = "longitude" ;
+	double DEPTH(N_OBS, N_LEVELS) ;
+		DEPTH:units = "metre" ;
+		DEPTH:long_name = "Depth" ;
+	double JULD(N_OBS) ;
+		JULD:units = "days since JULD_REFERENCE" ;
+		JULD:long_name = "Julian day" ;
+	char STATION_IDENTIFIER(N_OBS, STRINGWMO) ;
+		STATION_IDENTIFIER:long_name = "Station identifier" ;
+	char STATION_TYPE(N_OBS, STRINGTYP) ;
+		STATION_TYPE:long_name = "Code instrument type" ;
+	int DEPTH_QC(N_OBS, N_LEVELS) ;
+		DEPTH_QC:long_name = "Quality on depth" ;
+		DEPTH_QC:Conventions = "U.S. Integrated Ocean Observing System, 2017. Manual for the Use of Real-Time Oceanographic Data Quality Control Flags, Version 1.1" ;
+	int DEPTH_QC_FLAGS(N_OBS, N_LEVELS, N_QCF) ;
+		DEPTH_QC_FLAGS:long_name = "Quality on depth" ;
+		DEPTH_QC_FLAGS:Conventions = "OPS flag conventions" ;
+	int OBSERVATION_QC(N_OBS) ;
+		OBSERVATION_QC:long_name = "Quality on observation" ;
+		OBSERVATION_QC:Conventions = "U.S. Integrated Ocean Observing System, 2017. Manual for the Use of Real-Time Oceanographic Data Quality Control Flags, Version 1.1" ;
+	int OBSERVATION_QC_FLAGS(N_OBS, N_QCF) ;
+		OBSERVATION_QC_FLAGS:long_name = "Quality on observation" ;
+		OBSERVATION_QC_FLAGS:Conventions = "OPS flag conventions" ;
+	int POSITION_QC(N_OBS) ;
+		POSITION_QC:long_name = "Quality on position" ;
+		POSITION_QC:Conventions = "U.S. Integrated Ocean Observing System, 2017. Manual for the Use of Real-Time Oceanographic Data Quality Control Flags, Version 1.1" ;
+	int POSITION_QC_FLAGS(N_OBS, N_QCF) ;
+		POSITION_QC_FLAGS:long_name = "Quality on position" ;
+		POSITION_QC_FLAGS:Conventions = "OPS flag conventions" ;
+	int JULD_QC(N_OBS) ;
+		JULD_QC:long_name = "Quality on date and time" ;
+		JULD_QC:Conventions = "U.S. Integrated Ocean Observing System, 2017. Manual for the Use of Real-Time Oceanographic Data Quality Control Flags, Version 1.1" ;
+	int JULD_QC_FLAGS(N_OBS, N_QCF) ;
+		JULD_QC_FLAGS:long_name = "Quality on date and time" ;
+		JULD_QC_FLAGS:Conventions = "OPS flag conventions" ;
+	int ORIGINAL_FILE_INDEX(N_OBS) ;
+		ORIGINAL_FILE_INDEX:long_name = "Index in original data file" ;
+	double ICECONC_OBS(N_OBS, N_LEVELS) ;
+		ICECONC_OBS:long_name = "ice area fraction" ;
+		ICECONC_OBS:units = "Fraction" ;
+	double ICECONC_Hx(N_OBS, N_LEVELS) ;
+		ICECONC_Hx:long_name = "ice area fraction Hx" ;
+		ICECONC_Hx:units = "Fraction" ;
+	int ICECONC_QC_FLAGS(N_OBS, N_QCF) ;
+	int ICECONC_LEVEL_QC_FLAGS(N_OBS, N_LEVELS, N_QCF) ;
+	int ICECONC_QC(N_OBS) ;
+		ICECONC_QC:Conventions = "U.S. Integrated Ocean Observing System, 2017. Manual for the Use of Real-Time Oceanographic Data Quality Control Flags, Version 1.1" ;
+	int ICECONC_LEVEL_QC(N_OBS, N_LEVELS) ;
+		ICECONC_LEVEL_QC:Conventions = "U.S. Integrated Ocean Observing System, 2017. Manual for the Use of Real-Time Oceanographic Data Quality Control Flags, Version 1.1" ;
+	int ICECONC_IOBSI(N_OBS) ;
+		ICECONC_IOBSI:long_name = "ORCA grid search I coordinate" ;
+	int ICECONC_IOBSJ(N_OBS) ;
+		ICECONC_IOBSJ:long_name = "ORCA grid search J coordinate" ;
+	int ICECONC_IOBSK(N_OBS, N_LEVELS) ;
+		ICECONC_IOBSK:long_name = "ORCA grid search K coordinate" ;
+	char ICECONC_GRID(STRINGGRID) ;
+		ICECONC_GRID:long_name = "ORCA grid search grid (T,U,V)" ;
+	double SST_OBS(N_OBS, N_LEVELS) ;
+		SST_OBS:long_name = "sea_surface_temperature" ;
+		SST_OBS:units = "Fraction" ;
+	double SST_Hx(N_OBS, N_LEVELS) ;
+		SST_Hx:long_name = "sea_surface_temperature Hx" ;
+		SST_Hx:units = "Fraction" ;
+	int SST_QC_FLAGS(N_OBS, N_QCF) ;
+	int SST_LEVEL_QC_FLAGS(N_OBS, N_LEVELS, N_QCF) ;
+	int SST_QC(N_OBS) ;
+		SST_QC:Conventions = "U.S. Integrated Ocean Observing System, 2017. Manual for the Use of Real-Time Oceanographic Data Quality Control Flags, Version 1.1" ;
+	int SST_LEVEL_QC(N_OBS, N_LEVELS) ;
+		SST_LEVEL_QC:Conventions = "U.S. Integrated Ocean Observing System, 2017. Manual for the Use of Real-Time Oceanographic Data Quality Control Flags, Version 1.1" ;
+	int SST_IOBSI(N_OBS) ;
+		SST_IOBSI:long_name = "ORCA grid search I coordinate" ;
+	int SST_IOBSJ(N_OBS) ;
+		SST_IOBSJ:long_name = "ORCA grid search J coordinate" ;
+	int SST_IOBSK(N_OBS, N_LEVELS) ;
+		SST_IOBSK:long_name = "ORCA grid search K coordinate" ;
+	char SST_GRID(STRINGGRID) ;
+		SST_GRID:long_name = "ORCA grid search grid (T,U,V)" ;
+
+// global attributes:
+		:title = "NEMO observation operator output" ;
+		:Convention = "NEMO unified observation operator output" ;
+data:
+
+ JULD_REFERENCE = "20210630120000" ;
+
+ VARIABLES =
+  "ICECONC ",
+  "SST     " ;
+
+ ENTRIES =
+  "Hx      " ;
+
+ LATITUDE = 31.029390335083, 62.4358901977539, -65.2853622436523, 
+    -51.8797912597656, 41.8941993713379, 22.6518993377686, 3.32629990577698, 
+    -15.9160003662109, -35.2416000366211, -54.4838981628418, -73.7261962890625 ;
+
+ LONGITUDE = 168.337997436523, 31.2149505615234, -24.9150104522705, 
+    -154.481994628906, 38.443000793457, -148.292999267578, 25.1149997711182, 
+    -161.621002197266, 11.7869997024536, -174.949005126953, -1.68499994277954 ;
+
+ DEPTH =
+  0,
+  0,
+  0,
+  0,
+  0,
+  0,
+  0,
+  0,
+  0,
+  0,
+  0 ;
+
+ JULD = 0, 0, 0, 0, -0.5, -0.5, -0.5, -0.5, -0.5, -0.5, -0.5 ;
+
+ STATION_IDENTIFIER =
+  "        ",
+  "        ",
+  "        ",
+  "        ",
+  "        ",
+  "        ",
+  "        ",
+  "        ",
+  "        ",
+  "        ",
+  "        " ;
+
+ STATION_TYPE =
+  "    ",
+  "    ",
+  "    ",
+  "    ",
+  "    ",
+  "    ",
+  "    ",
+  "    ",
+  "    ",
+  "    ",
+  "    " ;
+
+ DEPTH_QC =
+  _,
+  _,
+  _,
+  _,
+  _,
+  _,
+  _,
+  _,
+  _,
+  _,
+  _ ;
+
+ DEPTH_QC_FLAGS =
+  _, _,
+  _, _,
+  _, _,
+  _, _,
+  _, _,
+  _, _,
+  _, _,
+  _, _,
+  _, _,
+  _, _,
+  _, _ ;
+
+ OBSERVATION_QC = 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 ;
+
+ OBSERVATION_QC_FLAGS =
+  _, _,
+  _, _,
+  _, _,
+  _, _,
+  _, _,
+  _, _,
+  _, _,
+  _, _,
+  _, _,
+  _, _,
+  _, _ ;
+
+ POSITION_QC = _, _, _, _, _, _, _, _, _, _, _ ;
+
+ POSITION_QC_FLAGS =
+  _, _,
+  _, _,
+  _, _,
+  _, _,
+  _, _,
+  _, _,
+  _, _,
+  _, _,
+  _, _,
+  _, _,
+  _, _ ;
+
+ JULD_QC = _, _, _, _, _, _, _, _, _, _, _ ;
+
+ JULD_QC_FLAGS =
+  _, _,
+  _, _,
+  _, _,
+  _, _,
+  _, _,
+  _, _,
+  _, _,
+  _, _,
+  _, _,
+  _, _,
+  _, _ ;
+
+ ORIGINAL_FILE_INDEX = _, _, _, _, _, _, _, _, _, _, _ ;
+
+ ICECONC_OBS =
+  0,
+  99999,
+  0.996299982070923,
+  0,
+  0,
+  0,
+  0,
+  0,
+  0,
+  0,
+  0 ;
+
+ ICECONC_Hx =
+  0,
+  99999,
+  0,
+  0,
+  99999,
+  0,
+  99999,
+  0,
+  0,
+  0,
+  99999 ;
+
+ ICECONC_QC_FLAGS =
+  64, _,
+  0, _,
+  64, _,
+  64, _,
+  0, _,
+  64, _,
+  0, _,
+  64, _,
+  64, _,
+  64, _,
+  0, _ ;
+
+ ICECONC_LEVEL_QC_FLAGS =
+  _, _,
+  _, _,
+  _, _,
+  _, _,
+  _, _,
+  _, _,
+  _, _,
+  _, _,
+  _, _,
+  _, _,
+  _, _ ;
+
+ ICECONC_QC = 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 ;
+
+ ICECONC_LEVEL_QC =
+  1,
+  1,
+  1,
+  1,
+  1,
+  1,
+  1,
+  1,
+  1,
+  1,
+  1 ;
+
+ ICECONC_IOBSI = _, _, _, _, _, _, _, _, _, _, _ ;
+
+ ICECONC_IOBSJ = _, _, _, _, _, _, _, _, _, _, _ ;
+
+ ICECONC_IOBSK =
+  _,
+  _,
+  _,
+  _,
+  _,
+  _,
+  _,
+  _,
+  _,
+  _,
+  _ ;
+
+ ICECONC_GRID = "T" ;
+
+ SST_OBS =
+  18,
+  99999,
+  18,
+  18,
+  18,
+  18,
+  0,
+  18,
+  18,
+  18,
+  18 ;
+
+ SST_Hx =
+  18.1723855075021,
+  99999,
+  17.6373035177142,
+  17.7117789460927,
+  99999,
+  18.1258438720372,
+  99999,
+  17.9115777814692,
+  17.8042133258748,
+  17.6973116928406,
+  99999 ;
+
+ SST_QC_FLAGS =
+  _, _,
+  _, _,
+  _, _,
+  _, _,
+  _, _,
+  _, _,
+  _, _,
+  _, _,
+  _, _,
+  _, _,
+  _, _ ;
+
+ SST_LEVEL_QC_FLAGS =
+  _, _,
+  _, _,
+  _, _,
+  _, _,
+  _, _,
+  _, _,
+  _, _,
+  _, _,
+  _, _,
+  _, _,
+  _, _ ;
+
+ SST_QC = 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 ;
+
+ SST_LEVEL_QC =
+  1,
+  1,
+  1,
+  1,
+  1,
+  1,
+  1,
+  1,
+  1,
+  1,
+  1 ;
+
+ SST_IOBSI = _, _, _, _, _, _, _, _, _, _, _ ;
+
+ SST_IOBSJ = _, _, _, _, _, _, _, _, _, _, _ ;
+
+ SST_IOBSK =
+  _,
+  _,
+  _,
+  _,
+  _,
+  _,
+  _,
+  _,
+  _,
+  _,
+  _ ;
+
+ SST_GRID = "T" ;
+}


### PR DESCRIPTION
### Description

If nemo-feedback is configured to output hofx data for two different observation variables the data would be interleaved and incomprehensible in the feedback file. This is an indexing issue.

### Summary of changes

* fix the indexing of data when there are two variables in the hofx obsvector. This needs to match the indexing used in ufo::ObsOperators (for example the [identity operator](https://github.com/JCSDA-internal/ufo/blob/develop/src/ufo/identity/ObsIdentity.cc#L66))
* add a test to read and write data when there are two variables present