### PR TITLE
Added setting of fill values for additional variables.

### DIFF
--- a/src/nemo-feedback/NemoFeedback.cc
+++ b/src/nemo-feedback/NemoFeedback.cc
@@ -409,6 +409,11 @@ void NemoFeedback::postFilter(const ufo::GeoVaLs & gv,
                               + "/" + ufo_name, Here());
       } else {
         obsdb_.get_db(ioda_group, ufo_name, variable_data);
+        auto missing_value = util::missingValue(variable_data[0]);
+        for (int i=0; i < n_obs; ++i) {
+          if (variable_data[i] == missing_value)
+            variable_data[i] = NemoFeedbackWriter::double_fillvalue;
+        }
         fdbk_writer.write_variable_surf(
             n_obs,
             n_obs_to_write,


### PR DESCRIPTION
Apart from HofX data, additional variables are currently written into the feedback files exactly as they are read from the obs database. This means that their fill values are as defined by JEDI instead of the feedback file convention of 99999. This PR adds in the code to set the fill values to 99999, as is done for other data. 

I reran the tests, even though this change would not cause a difference in the test outputs, and found that there were some small differences in the SST_Hx data ([test output](http://fcm1/cylc-review/view/hadgs?&suite=jopa&no_fuzzy_time=0&path=log/job/1/ctest_all_jopa__lfric_gnu9_rhel7/01/job.out)). This must be unrelated to this change, so I don't know the cause. 