### PR TITLE
Use Bash syntax for compat with Cray XC40

### DIFF
--- a/src/tests/mains/compare_nc_cdl.sh
+++ b/src/tests/mains/compare_nc_cdl.sh
@@ -1,11 +1,8 @@
 #!/usr/bin/env bash
 
-set -e 
+set -euo pipefail
 
-test_file=${1}
-test_cdl="${test_file::-3}.cdl"
-ref_cdl=${2}
+test_file="$1"
+ref_cdl="$2"
 
-ncdump ${test_file} > ${test_cdl}
-
-diff ${test_cdl} ${ref_cdl}
+diff -u <(ncdump "${test_file}") "${ref_cdl}"


### PR DESCRIPTION
The `${x:offset:length}` syntax does not work on old Bash on Cray XC40.

This change uses the process substitution syntax that does not require creation of an intermediate file. The new syntax works on old and new versions of Bash that concern us.