### PR TITLE
tests: Update following orca-jedi/enable-basic-mpi

### DIFF
--- a/src/tests/testoutput/test_hofx_feedback_writer.ref
+++ b/src/tests/testoutput/test_hofx_feedback_writer.ref
@@ -3,14 +3,14 @@ Test     :  Model state valid at time: 2021-06-28T00:00:00Z
 Test     :     2 variables: ice_area_fraction, ice_area_fraction_background_error
 Test     :     atlas field norms:
 Test     :         ice_area_fraction: 0.0
-Test     :         ice_area_fraction_background_error: 0.00303628
+Test     :         ice_area_fraction_background_error: 3.06841e-03
 
 Test     : Final state: 
 Test     :  Model state valid at time: 2021-07-01T00:00:00Z
 Test     :     2 variables: ice_area_fraction, ice_area_fraction_background_error
 Test     :     atlas field norms:
-Test     :         ice_area_fraction: 0.00320233
-Test     :         ice_area_fraction_background_error: 0.00303628
+Test     :         ice_area_fraction: 3.16981e-03
+Test     :         ice_area_fraction_background_error: 3.06841e-03
 
 Test     : H(x): 
 Test     : Sea Ice nobs= 7 Min=0.00000e+00, Max=4.95000e-01, RMS=1.87092e-01

--- a/src/tests/testoutput/test_hofx_profiles_writer.ref
+++ b/src/tests/testoutput/test_hofx_profiles_writer.ref
@@ -2,9 +2,9 @@ Test     : State:
 Test     :  Model state valid at time: 2021-06-30T00:00:00Z
 Test     :     3 variables: sea_water_potential_temperature, sea_water_potential_temperature_background_error, depth
 Test     :     atlas field norms:
-Test     :         sea_water_potential_temperature: 9.64887e-02
-Test     :         sea_water_potential_temperature_background_error: 3.50599e-04
-Test     :         depth: 2.03428e-01
+Test     :         sea_water_potential_temperature: 9.73262e-02
+Test     :         sea_water_potential_temperature_background_error: 3.54309e-04
+Test     :         depth: 2.05581e-01
 
 Test     : H(x): 
 Test     : Sea Temperature nobs= 7 Min=1.78889e+01, Max=1.81944e+01, RMS=1.80641e+01

--- a/src/tests/testoutput/test_hofx_two_vars_writer.ref
+++ b/src/tests/testoutput/test_hofx_two_vars_writer.ref
@@ -2,19 +2,19 @@ Test     : Initial state:
 Test     :  Model state valid at time: 2021-06-29T21:00:00Z
 Test     :     4 variables: ice_area_fraction, sea_surface_temperature, ice_area_fraction_background_error, sea_surface_temperature_background_error
 Test     :     atlas field norms:
-Test     :         ice_area_fraction: 0.00323467
-Test     :         sea_surface_temperature: 0.136432
-Test     :         ice_area_fraction_background_error: 0.00303628
-Test     :         sea_surface_temperature_background_error: 0.000607255
+Test     :         ice_area_fraction: 3.20183e-03
+Test     :         sea_surface_temperature: 1.37607e-01
+Test     :         ice_area_fraction_background_error: 3.06841e-03
+Test     :         sea_surface_temperature_background_error: 6.13682e-04
 
 Test     : Final state: 
 Test     :  Model state valid at time: 2021-07-01T21:00:00Z
 Test     :     4 variables: ice_area_fraction, sea_surface_temperature, ice_area_fraction_background_error, sea_surface_temperature_background_error
 Test     :     atlas field norms:
-Test     :         ice_area_fraction: 0.00320233
-Test     :         sea_surface_temperature: 0.136508
-Test     :         ice_area_fraction_background_error: 0.00303628
-Test     :         sea_surface_temperature_background_error: 0.000607255
+Test     :         ice_area_fraction: 3.16981e-03
+Test     :         sea_surface_temperature: 1.37683e-01
+Test     :         ice_area_fraction_background_error: 3.06841e-03
+Test     :         sea_surface_temperature_background_error: 6.13682e-04
 
 Test     : H(x): 
 Test     : Sea Ice nobs= 14 Min=0.00000e+00, Max=1.81824e+01, RMS=1.26409e+01


### PR DESCRIPTION
The field norms calculation was updated as part of [orca-jedi/enable-basic-mpi](https://github.com/MetOffice/orca-jedi/pull/10). This change is to update the tests that depend upon this calculation.