### PR TITLE
feature: use obs from ObsValue or DerivedObsValue

### DIFF
--- a/src/nemo-feedback/NemoFeedback.cc
+++ b/src/nemo-feedback/NemoFeedback.cc
@@ -187,7 +187,9 @@ void NemoFeedback::postFilter(const ufo::GeoVaLs & gv,
         parameters_.variables.value()) {
     auto nemo_name = nemoVariableParams.nemoName.value();
     auto ufo_name = nemoVariableParams.name.value();
-    obsdb_.get_db("ObsValue", ufo_name, variable_data);
+    auto obs_group = nemoVariableParams.iodaObsGroup.value()
+        .value_or("ObsValue");
+    obsdb_.get_db(obs_group, ufo_name, variable_data);
     auto missing_value = util::missingValue(variable_data[0]);
     oops::Log::trace() << "Missing value OBS: " << missing_value << std::endl;
     for (int i=0; i < n_locs; ++i) {

--- a/src/nemo-feedback/NemoFeedbackParameters.h
+++ b/src/nemo-feedback/NemoFeedbackParameters.h
@@ -34,6 +34,7 @@ class NemoFeedbackVariableParameters : public oops::Parameters {
  public:
   oops::RequiredParameter<std::string> name{"name", this};
   oops::RequiredParameter<std::string> nemoName{"nemo name", this};
+  oops::OptionalParameter<std::string> iodaObsGroup{"ioda group", this};
   oops::RequiredParameter<std::string> units{"units", this};
   oops::RequiredParameter<std::string> longName{"long name", this};
   oops::OptionalParameter<bool> extravar{"extra variable", this};


### PR DESCRIPTION
Add an optional parameter to specify the ioda group to use to source the observation data. Previously this was hard-coded to ObsValue, however it is concievable that we would want to write the data from the DerivedObsValue instead.