### PR TITLE
remove legacy ecbuild_find_package calls

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,19 +18,19 @@ set( CMAKE_DIRECTORY_LABELS "nemo-feedback" )
 ################################################################################
 # Required packages
 
-ecbuild_find_package( NAME eckit VERSION 1.16 REQUIRED )
+find_package( eckit 1.16 REQUIRED )
 ecbuild_debug( "   eckit_FEATURES : [${eckit_FEATURES}]" )
 
-ecbuild_find_package( NAME oops )
+find_package( oops REQUIRED )
 ecbuild_debug( "   oops_FEATURES : [${oops_FEATURES}]" )
 
-ecbuild_find_package( NAME ioda )
+find_package( ioda REQUIRED )
 ecbuild_debug( "   ioda_FEATURES : [${ioda_FEATURES}]" )
 
-ecbuild_find_package( NAME ufo )
+find_package( ufo REQUIRED )
 ecbuild_debug( "   ufo_FEATURES : [${ufo_FEATURES}]" )
 
-ecbuild_find_package( NAME orca-jedi )
+find_package( orca-jedi )
 
 #ecbuild_find_package( NAME NetCDF COMPONENTS CXX)
 find_package( NetCDF COMPONENTS CXX)


### PR DESCRIPTION
While building with bb-env nemo-feedback cannot be configured with recent CMake.  Some bundles have cmake_minimum_required set to version 3.3.2 to make this work.  I suggest we replace calls to legacy `ecbuild_find_package` with native CMake `find_package` instead. 

```
-- ---------------------------------------------------------
-- Adding bundle project nemo-feedback
-- ---------------------------------------------------------
-- [nemo-feedback] (0.4.0)
-- Feature TESTS enabled
-- Feature TESTS enabled
-- nemo-feedback FOUND eckit: /scratch/fra6/jedi_test/b-jopa-bundle/eckit (found version "1.19.0")
--    ECKIT_LIBRARIES : [eckit eckit_cmd eckit_sql eckit_geometry eckit_linalg eckit_maths eckit_mpi eckit_option eckit_web eckit_test_value_custom_params]
-- Found OpenMP_Fortran: -fopenmp (found version "4.5") 
-- Found OpenMP: TRUE (found version "4.5") found components: CXX Fortran 
-- Found MPI: TRUE (found version "3.1") found components: CXX Fortran 
-- Found OpenMP_CXX: -fopenmp (found version "4.5") 
-- Found OpenMP: TRUE (found version "4.5") found components: CXX 
-- nemo-feedback FOUND oops: /scratch/fra6/jedi_test/b-jopa-bundle/oops (found version "1.3.0")
--    oops_LIBRARIES : [oops]
-- Found HDF5: /home/h03/darth/opt/bb-stack/spice_gnu-v9/lib/libhdf5.so;/home/h03/darth/opt/bb-stack/spice_gnu-v9/lib/libmpifort.so;/home/h03/darth/opt/bb-stack/spice_gnu-v9/lib/libmpi.so;/home/h03/darth/opt/bb-stack/spice_gnu-v9/lib64/libgfortran.so;/usr/lib64/libz.so;/usr/lib64/libdl.so;/usr/lib64/libm.so (found version "1.12.0") found components: C HL 
-- Found OpenMP_CXX: -fopenmp (found version "4.5") 
-- Found OpenMP_Fortran: -fopenmp (found version "4.5") 
-- Found OpenMP: TRUE (found version "4.5") found components: C CXX Fortran 
CMake Error at /scratch/fra6/jedi_test/b-jopa-bundle/ioda/ioda-post-import.cmake:7 (add_library):
  add_library cannot create ALIAS target "ioda::ioda" because another target
  with the same name already exists.
Call Stack (most recent call first):
  /scratch/fra6/jedi_test/b-jopa-bundle/ioda/ioda-config.cmake:81 (include)
  /home/h03/darth/opt/bb-stack/spice_gnu-v9/share/ecbuild/cmake/ecbuild_find_package.cmake:203 (find_package)
  nemo-feedback/CMakeLists.txt:27 (ecbuild_find_package)


CMake Error at /scratch/fra6/jedi_test/b-jopa-bundle/ioda/ioda-post-import.cmake:8 (add_library):
  add_library cannot create ALIAS target "ioda::engines" because another
  target with the same name already exists.
Call Stack (most recent call first):
  /scratch/fra6/jedi_test/b-jopa-bundle/ioda/ioda-config.cmake:81 (include)
  /home/h03/darth/opt/bb-stack/spice_gnu-v9/share/ecbuild/cmake/ecbuild_find_package.cmake:203 (find_package)
  nemo-feedback/CMakeLists.txt:27 (ecbuild_find_package)


CMake Error at /scratch/fra6/jedi_test/b-jopa-bundle/ioda/ioda-post-import.cmake:11 (add_library):
  add_library cannot create ALIAS target "ioda::Python" because another
  target with the same name already exists.
Call Stack (most recent call first):
  /scratch/fra6/jedi_test/b-jopa-bundle/ioda/ioda-config.cmake:81 (include)
  /home/h03/darth/opt/bb-stack/spice_gnu-v9/share/ecbuild/cmake/ecbuild_find_package.cmake:203 (find_package)
  nemo-feedback/CMakeLists.txt:27 (ecbuild_find_package)
```