### PR TITLE
Update check on number of profile data

### DIFF
--- a/src/nemo-feedback/NemoFeedbackReduce.cc
+++ b/src/nemo-feedback/NemoFeedbackReduce.cc
@@ -107,7 +107,7 @@ void NemoFeedbackReduce::reduce_profile_data(
             + std::to_string(n_unred_prof_obs), Here());
   }
   // with profile data n_obs is the number of profiles and hence is not equal 
-  // n_locs, which is the number of data points, and so we setup new 
+  // to n_locs, which is the number of data points, and so we set up new 
   // record_starts and counts based on the new data vector.
   data_out.clear();
   const size_t n_prof_obs = std::accumulate(reduced_counts.begin(),


### PR DESCRIPTION
The check of number of data in NemoFeedbackReduce::reduce_profile_data incorrectly throws an error when a whole profile is not being written to file. This is because data_in does not include the information about those profiles because they are ignored in https://github.com/MetOffice/nemo-feedback/blob/develop/src/nemo-feedback/NemoFeedback.cc#L448.