### PR TITLE
Fix for standalone build.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ cmake_minimum_required( VERSION 3.12 FATAL_ERROR )
 ################################################################################
 # Initialise project nemo-feedback
 
-project( nemo-feedback VERSION 2.4.0 LANGUAGES CXX Fortran )
+project( nemo-feedback VERSION 0.4.0 LANGUAGES CXX Fortran )
 find_package( ecbuild QUIET )
 include( ecbuild_system NO_POLICY_SCOPE )
 ecbuild_declare_project()
@@ -30,7 +30,7 @@ find_package( ufo REQUIRED )
 ecbuild_debug( "   ufo_FEATURES : [${ufo_FEATURES}]" )
 
 #ecbuild_find_package( NAME NetCDF COMPONENTS CXX)
-find_package( NetCDF COMPONENTS CXX Fortran)
+find_package( NetCDF COMPONENTS CXX)
 ecbuild_debug( "   NetCDF_FEATURES: [${NetCDF_FEATURES}]" )
 
 


### PR DESCRIPTION
I have been trying to build nemo-feedback as a standalone repository, i.e. not as part of a bundle and I found these changes were necessary for this to work. It is just minor tweaks to the detection of some packages.

Test output is here: http://fcm1/cylc-review/taskjobs/frwd?&suite=NemoFeedbackStandalone