### PR TITLE
Fix NetCDF detection for standalone builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,7 +29,7 @@ ecbuild_debug( "   ioda_FEATURES : [${ioda_FEATURES}]" )
 find_package( ufo REQUIRED )
 ecbuild_debug( "   ufo_FEATURES : [${ufo_FEATURES}]" )
 
-#ecbuild_find_package( NAME NetCDF COMPONENTS CXX)
+ecbuild_find_package( NAME NetCDF COMPONENTS CXX Fortran )
 find_package( NetCDF COMPONENTS CXX)
 ecbuild_debug( "   NetCDF_FEATURES: [${NetCDF_FEATURES}]" )
 


### PR DESCRIPTION
Re-visiting this, the problem I had without the NetCDF Fortran detection was getting this cmake failure:

CMake Error at /home/h01/frwd/cylc-run/bb-build-standalone/work/1/make_oops__spice_gnu/install/lib64/cmake/oops/oops-targets.cmake:61 (set_target_properties):
  The link interface of target "oops" contains:

    NetCDF::NetCDF_Fortran

  but the target was not found.  Possible reasons include:

    * There is a typo in the target name.
    * A find_package call is missing for an IMPORTED target.
    * An ALIAS target is missing.

The trouble is that it is difficult to say where the actual problem is (nemo-feedback?  oops?  netcdf-fortran?).  However inserting a line to detect netcdf-fortran in the nemo-feedback cmake file does fix the issue.