### PR TITLE
read_hofx indexing

### DIFF
--- a/src/nemo-feedback/NemoFeedback.cc
+++ b/src/nemo-feedback/NemoFeedback.cc
@@ -70,7 +70,7 @@ struct VariableData {
                          << std::endl;
       // Convert oops missing values to NEMO missing value
       double missing_value = util::missingValue(static_cast<double>(0));
-      if (ov.n_locs() > 0)
+      if (ov.nlocs() > 0)
           missing_value = util::missingValue(ov[var_it_dist]);
       oops::Log::trace() << "Missing value HofX: " << missing_value
                          << std::endl;
@@ -79,7 +79,7 @@ struct VariableData {
       };
       ASSERT_MSG(data.size() == ov.nlocs(),
             "NemoFeedback::read_hofx data.size() != ov.nlocs()");
-      for (size_t obIdx = 0; obIdx < ov.n_locs(); ++obIdx) {
+      for (size_t obIdx = 0; obIdx < ov.nlocs(); ++obIdx) {
         if (ov[ov_indexer(obIdx)] == missing_value) {
           data[obIdx] = typeToFill::value<T>();
         } else {


### PR DESCRIPTION
The read_hofx function currently uses coords information passed to it to copy data from the obs vector into another vector. The coords information it is given is for the reduced data, so the copy is not working. This can be solved by not using the coords information and do a simple copy from one vector to another.