### PR TITLE
set c++ standard at project root level

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,9 @@ cmake_minimum_required( VERSION 3.12 FATAL_ERROR )
 # Initialise project nemo-feedback
 
 project( nemo-feedback VERSION 0.4.0 LANGUAGES CXX Fortran )
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
 find_package( ecbuild QUIET )
 include( ecbuild_system NO_POLICY_SCOPE )
 ecbuild_declare_project()

--- a/src/nemo-feedback/CMakeLists.txt
+++ b/src/nemo-feedback/CMakeLists.txt
@@ -26,7 +26,7 @@ ecbuild_add_library( TARGET nemo_feedback
                      INSTALL_HEADERS LISTED
                      HEADER_DESTINATION ${INSTALL_INCLUDE_DIR}/nemo-feedback
                    )
-set_target_properties(nemo_feedback PROPERTIES CXX_STANDARD 17)
+
 target_link_libraries( nemo_feedback PUBLIC ufo ioda oops NetCDF::NetCDF_CXX)
 target_include_directories(nemo_feedback PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/src>
                                                 $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)


### PR DESCRIPTION
As discussed offline with @twsearle I think it is better to set the C++ standard requirement at the root level of the project.