### PR TITLE
bugfix: Require a geovar only if the ioda group is HofX

### DIFF
--- a/src/tests/testinput/hofx_profiles_2var_writer.yaml
+++ b/src/tests/testinput/hofx_profiles_2var_writer.yaml
@@ -17,6 +17,8 @@ observations:
           type: H5File
           obsfile: testoutput/test_hofx3d_profiles_2var_writer_jopa_out.nc
       simulated variables: [waterPotentialTemperature, salinity]
+      observed variables: [waterPotentialTemperature, salinity]
+      derived variables: [waterTemperature]
     obs operator:
       name: VertInterp
       variables:
@@ -27,6 +29,11 @@ observations:
       observation vertical coordinate group: ObsValue
       interpolation method: linear
     obs filters:
+    - filter: Variable Assignment
+      assignments:
+      - name: DerivedObsValue/waterTemperature
+        type: float
+        value: 12.0
     - filter: NEMO Feedback Writer
       filename: testoutput/test_hofx3d_nc_prof_2vars_writer_out.nc
       reference date: 1950-01-01T00:00:00Z
@@ -48,6 +55,13 @@ observations:
         - name: salinity
           feedback suffix: Hx
           ioda group: HofX
+      - long name: Insitu temperature
+        name: waterTemperature
+        ioda group: DerivedObsValue
+        nemo name: TEMP
+        units: Degrees Celsius
+        extra variable: true
+
     benchmarkFlag: 1000 # just to keep the ObsFilters test happy
     flaggedBenchmark: 0
     HofX: hofx

--- a/src/tests/testoutput/test_hofx3d_nc_prof_2vars_writer_out_ref.cdl
+++ b/src/tests/testoutput/test_hofx3d_nc_prof_2vars_writer_out_ref.cdl
@@ -10,12 +10,14 @@ dimensions:
 	N_LEVELS = 6 ;
 	N_VARS = 2 ;
 	N_ENTRIES = 1 ;
+	N_EXTRA = 1 ;
 variables:
 	char JULD_REFERENCE(STRINGJULD) ;
 		JULD_REFERENCE:long_name = "Date of reference for julian days" ;
 		JULD_REFERENCE:Conventions = "YYYYMMDDHHMMSS" ;
 	char VARIABLES(N_VARS, STRINGNAM) ;
 		VARIABLES:long_name = "List of variables in feedback files" ;
+	char EXTRA(N_EXTRA, STRINGNAM) ;
 	char ENTRIES(N_ENTRIES, STRINGNAM) ;
 		ENTRIES:long_name = "List of additional entries for each variable in feedback files" ;
 	double LATITUDE(N_OBS) ;
@@ -122,6 +124,9 @@ variables:
 		PSAL_IOBSK:long_name = "ORCA grid search K coordinate" ;
 	char PSAL_GRID(STRINGGRID) ;
 		PSAL_GRID:long_name = "ORCA grid search grid (T,U,V)" ;
+	double TEMP(N_OBS, N_LEVELS) ;
+		TEMP:long_name = "Insitu temperature" ;
+		TEMP:units = "Degrees Celsius" ;
 
 // global attributes:
 		:title = "NEMO observation operator output" ;
@@ -133,6 +138,9 @@ data:
  VARIABLES =
   "POTM    ",
   "PSAL    " ;
+
+ EXTRA =
+  "TEMP    " ;
 
  ENTRIES =
   "Hx      " ;
@@ -276,4 +284,8 @@ data:
   _, _, _, _, _, _ ;
 
  PSAL_GRID = "T" ;
+
+ TEMP =
+  12, 12, 12, 12, 12, 12,
+  12, 12, 12, 12, 12, 12 ;
 }


### PR DESCRIPTION
### Description

When a variable is included in the configuration that is not available as a state variable, the model geometry will crash. This is because every observation variable in the configuration was assumed to have a corresponding state variable.

This is all caused by naively setting up the `geovars_` variable in the constructor using the list of observation variables in the filter configuration.

### Instructions to reproduce

In the oceansound configuration, adding the following that makes use of "waterTemperature":

```yaml
...
   - long name: Insitu temperature
     name: waterTemperature
     ioda group: DerivedObsValue
     nemo name: TEMP
     units: Degrees Celsius
     extra variable: true
...
```

this causes the crash with the `orca-jedi` error:

```
BadValue: orcamodel::Geometry::variableSizes variable name " " ocean_temperature not recognised. 
```

### Testing

The nemo-feedback test for `test_nemo_feedback_hofx_profiles_two_vars_writer` now includes the above insitu temperature variable without requiring a corresponding geoVaL.

- [x] [build mo-bundle and pass ctests](http://fcm1/cylc-review/taskjobs/tsearle?&suite=bb_mo_test_nf53)
- [x] [test oceansound example in sith](http://fcm1/cylc-review/taskjobs/tsearle?&suite=sith_191_spice_gl_ocn&cycles=20210701T0000Z)
