### PR TITLE
Update the stack environment script

### DIFF
--- a/ci/build.sh
+++ b/ci/build.sh
@@ -20,7 +20,7 @@ trap finally EXIT
 
 cd "${WORKD}"
 
-source /etc/profile.d/z10_spack_environment.sh
+source /opt/spack-environment/activate.sh
 
 rm -f "${HERE}/nemo-feedback"
 ln -s '..' "${HERE}/nemo-feedback"


### PR DESCRIPTION
Recent JCSDA container changes have changed how we load the environment inside the ci script. 

This change is also needed in MetOffice/orca-jedi/pull/55