### PR TITLE
Extend `processWhere` call

### DIFF
--- a/src/nemo-feedback/NemoFeedback.cc
+++ b/src/nemo-feedback/NemoFeedback.cc
@@ -153,7 +153,7 @@ void NemoFeedback::postFilter(const ufo::GeoVaLs & gv,
 
   // Handle the where option.
   std::vector<bool> to_write = ufo::processWhere(parameters_.where, data_,
-                                   ufo::WhereOperator::AND);
+                                                 ufo::WhereOperator::AND, "");
   if (to_write.size() != obsdb_.nlocs()) to_write.assign(obsdb_.nlocs(), true);
 
   // exclude all but the latest altimetry observations


### PR DESCRIPTION
## Description

Extend the call to `processWhere` to match the new signature introduced in JCSDA-internal/ufo#3258

This is a neutral change; if the empty string is used in the final argument then no caching is performed.

## Issue(s) addressed

No issue - tiny change

## Dependencies

Please merge at the same time as JCSDA-internal/ufo#3258

## Impact

N/A

## Checklist

- [ ] I have updated the unit tests to cover the change
- [ ] New functions are documented briefly via Doxygen comments in the code
- [ ] I have linted my code using cpplint
- [ ] I have run the unit tests
- [ ] I have run mo-bundle to check integration with the rest of JEDI and run the unit tests under all environments
