### PR TITLE
separate model variables and obs variables types

### DIFF
--- a/src/nemo-feedback/NemoFeedback.cc
+++ b/src/nemo-feedback/NemoFeedback.cc
@@ -21,6 +21,7 @@
 #include "ioda/ObsSpace.h"
 #include "ioda/ObsVector.h"
 #include "oops/base/Variables.h"
+#include "oops/base/ObsVariables.h"
 #include "oops/mpi/mpi.h"
 #include "oops/util/Logger.h"
 #include "oops/util/DateTime.h"
@@ -63,7 +64,6 @@ NemoFeedback::NemoFeedback(
 {
   oops::Log::trace() << "NemoFeedback constructor starting" << std::endl;
 
-  const std::vector<int> channels{};
   std::vector<std::string> obsGeoNames;
 
   // helper function to determine if a name is a new entry in the vector
@@ -90,7 +90,7 @@ NemoFeedback::NemoFeedback(
     }
   }
 
-  const oops::Variables obsGeoVars(obsGeoNames, channels);
+  const oops::ObsVariables obsGeoVars(obsGeoNames);
   geovars_ = nameMap_.convertName(obsGeoVars);
 
   // Generate lists of the variable name meta data to setup the file

--- a/src/nemo-feedback/NemoFeedback.h
+++ b/src/nemo-feedback/NemoFeedback.h
@@ -12,6 +12,7 @@
 #include "eckit/mpi/Comm.h"
 #include "ioda/ObsDataVector.h"
 #include "oops/base/Variables.h"
+#include "oops/base/ObsVariables.h"
 #include "oops/interface/ObsFilterBase.h"
 #include "oops/util/ObjectCounter.h"
 #include "oops/util/Printable.h"
@@ -48,7 +49,7 @@ class NemoFeedback : public oops::interface::ObsFilterBase<ufo::ObsTraits>,
   void checkFilterData(const oops::FilterStage filterStage) override {}
 
   oops::Variables requiredVars() const override {return geovars_;}
-  oops::Variables requiredHdiagnostics() const override {return extradiagvars_;}
+  oops::ObsVariables requiredHdiagnostics() const override {return extradiagvars_;}
 
  private:
   /// \brief write the data to the feedback file depending on chosen type
@@ -78,7 +79,7 @@ class NemoFeedback : public oops::interface::ObsFilterBase<ufo::ObsTraits>,
   ioda::ObsSpace & obsdb_;
   ufo::ObsFilterData data_;
   oops::Variables geovars_;
-  oops::Variables extradiagvars_;
+  oops::ObsVariables extradiagvars_;
   std::shared_ptr<ioda::ObsDataVector<int>> flags_;
   std::shared_ptr<ioda::ObsDataVector<float>> obsErrors_;
   NemoFeedbackParameters parameters_;


### PR DESCRIPTION
## Description
Use the new `oops::ObsVariables` for observations and `oops::Variables` for model variables.

## Issue(s) addressed

Resolves #69

## Impact

Resolves compile-time errors due to recent oops changes.

## Checklist

- [x] I have updated the unit tests to cover the change
- [x] I have linted my code using cpplint
- [x] I have run the unit tests
- [ ] I have run [mo-bundle](http://fcm1/cylc-review/taskjobs/tsearle/?suite=mobb-oops2591) to check integration with the rest of JEDI and run the unit tests under all environments
