### PR TITLE
add codeowners file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# These owners are the default owners for everything in the repo. Unless a
+# later match takes precedence, they will be requested for review when someone
+# opens a pull request.
+*       @twsearle


### PR DESCRIPTION
## Description

Twin of https://github.com/MetOffice/orca-jedi/pull/103

The github [CODEOWNERS file](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners) allows repository owners to specify owners of a repository or particular directories within a repo. This flexible approach allows automatic notification/addition of reviewers to pull requests relevant for that team or individual that is responsible for the repository. Later, we could add restrictions so that reviewers listed would have to accept the change before it could be merged, but I am not suggesting that right now.

Advantages:
 * guarantee that one of the reviewers has the ability to merge, meaning that we won't have any time between a change being marked accepted and merged.
 * the author of the PR would not have to figure out whose approval they need to get a change merged.

## Issue(s) addressed

Experiment to implement suggestion in https://github.com/orgs/JCSDA-internal/discussions/144
