### PR TITLE
cmake configure test only when BUILD_TESTING=ON

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2024-2025 Met Office
+# (C) British Crown Copyright 2024 Met Office
 
 add_subdirectory(nemo-feedback)
 if(BUILD_TESTING)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,5 +1,6 @@
-# (C) British Crown Copyright 2024 Met Office
+# (C) British Crown Copyright 2024-2025 Met Office
 
 add_subdirectory(nemo-feedback)
-add_subdirectory(tests)
-
+if(BUILD_TESTING)
+  add_subdirectory(tests)
+endif()


### PR DESCRIPTION
## Description

Determine whether to build tests by following the CTest module BUILD_TESTING option.

## Impact

Follow the CTest module BUILD_TESTING option.

## Checklist

- [ ] I have updated the unit tests to cover the change
- [ ] New functions are documented briefly via Doxygen comments in the code
- [ ] I have linted my code using cpplint
- [ ] I have run the unit tests
- [ ] I have run mo-bundle to check integration with the rest of JEDI and run the unit tests under all environments
