### PR TITLE
throw errors for warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
 env:
     REGISTRY: ghcr.io
-    IMAGE_NAME: twsearle/orca-jedi/ci-almalinux9:v1.7.0
+    IMAGE_NAME: twsearle/orca-jedi/ci-almalinux9:v1.9.2
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,6 +43,20 @@ ecbuild_debug( "   NetCDF_FEATURES: [${NetCDF_FEATURES}]" )
 #include( features/BOUNDSCHECKING )
 
 ################################################################################
+# Project-wide compiler options
+
+message( "   CMAKE_CXX_COMPILER_ID : ${CMAKE_CXX_COMPILER_ID}" )
+if(CMAKE_C_COMPILER_ID MATCHES "GNU|Clang")
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Werror")
+endif()
+if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror")
+endif()
+if(CMAKE_Fortran_COMPILER_ID MATCHES "GNU|Clang")
+  set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -Werror")
+endif()
+
+################################################################################
 # sources
 
 include_directories ( ${CMAKE_CURRENT_SOURCE_DIR}/src


### PR DESCRIPTION
## Description

Tighten up standards to remove warnings from the compilation of nemo-feedback.

## Issue(s) addressed

Similar to MetOffice/orca-jedi/issues/166


## Checklist

- [x] I have updated the unit tests to cover the change
- [x] I have linted my code using cpplint
- [x] I have run the unit tests
- [x] I have run mo-bundle to check integration with the rest of JEDI and run the unit tests under all environments
