### PR TITLE
Changes needed for ufo pr 4112

### DIFF
--- a/src/nemo-feedback/NemoFeedback.cc
+++ b/src/nemo-feedback/NemoFeedback.cc
@@ -45,13 +45,13 @@ constexpr std::string_view defaultDepthVariable{"depthBelowWaterSurface"};
 
 NemoFeedback::NemoFeedback(
     ioda::ObsSpace& obsdb, const Parameters_& params,
-    std::shared_ptr<ioda::ObsDataVector<int>> flags,
-    std::shared_ptr<ioda::ObsDataVector<float>> obsErrors)
+    ioda::ObsDataVector<int> & flags,
+    ioda::ObsDataVector<float> & obsErrors)
     : obsdb_(obsdb),
       data_(obsdb_),
       geovars_(),
-      flags_(std::move(flags)),
-      obsErrors_(std::move(obsErrors)),
+      flags_(flags),
+      obsErrors_(obsErrors),
       parameters_(params),
       nameMap_(params.geoVaLsAliasFile.value()),
       validityTime_(obsdb.windowStart() +
@@ -216,9 +216,9 @@ void NemoFeedback::write_all_data(
     if (obsdb_.has("QCFlags", ufo_name)) {
       variableQCFlagsData = creator.create("QCFlags", ufo_name, int32_t(0));
     } else {
-      const size_t iv = flags_->varnames().find(ufo_name);
+      const size_t iv = flags_.varnames().find(ufo_name);
       std::vector<int32_t> variable_qcFlags;
-      variable_qcFlags.assign((*flags_)[iv].begin(), (*flags_)[iv].end());
+      variable_qcFlags.assign(flags_[iv].begin(), flags_[iv].end());
       variableQCFlagsData =
           feedback_io::Data<int32_t>(creator.indexer(), variable_qcFlags);
     }

--- a/src/nemo-feedback/NemoFeedback.h
+++ b/src/nemo-feedback/NemoFeedback.h
@@ -35,8 +35,8 @@ class NemoFeedback : public ufo::ObsFilterBase,
   typedef NemoFeedbackParameters Parameters_;
 
   NemoFeedback(ioda::ObsSpace &, const Parameters_ &,
-               std::shared_ptr<ioda::ObsDataVector<int> > flags,
-               std::shared_ptr<ioda::ObsDataVector<float> > obsErrors);
+               ioda::ObsDataVector<int> & flags,
+               ioda::ObsDataVector<float> & obsErrors);
   ~NemoFeedback();
 
   void preProcess() override {}
@@ -80,8 +80,8 @@ class NemoFeedback : public ufo::ObsFilterBase,
   ufo::ObsFilterData data_;
   oops::Variables geovars_;
   oops::ObsVariables extradiagvars_;
-  std::shared_ptr<ioda::ObsDataVector<int>> flags_;
-  std::shared_ptr<ioda::ObsDataVector<float>> obsErrors_;
+  ioda::ObsDataVector<int> & flags_;
+  ioda::ObsDataVector<float> & obsErrors_;
   NemoFeedbackParameters parameters_;
   ufo::VariableNameMap nameMap_;
   const util::DateTime validityTime_;


### PR DESCRIPTION
This PR is needed because of changes to pass the qc flags and errors as references rather than shared pointers in ufo, https://github.com/JCSDA-internal/ufo/pull/4112.

This is a coordinated merge with the following prs:
- [ufo](https://github.com/JCSDA-internal/ufo/pull/4112)
- [oops](https://github.com/JCSDA-internal/oops/pull/3267)
- [pyiri](https://github.com/JCSDA-internal/pyiri-jedi/pull/174)
- [opsinputs](https://github.com/MetOffice/opsinputs/pull/283)

build-group=https://github.com/JCSDA-internal/oops/pull/3267
build-group=https://github.com/JCSDA-internal/pyiri-jedi/pull/174
build-group=https://github.com/MetOffice/opsinputs/pull/283
build-group=https://github.com/JCSDA-internal/ufo/pull/4112

The full mobundle testing has been run and output can be found here:
https://cylchub/services/cylc-review/cycles/michael.c.cooke/?suite=mobundle-ufo4112

The failure in ufo for the mo-bundle testing is a known problem with a ufo ctest and unrelated to this change:
https://cylchub/services/cylc-review/view/michael.c.cooke?&suite=mobundle-ufo4112&no_fuzzy_time=0&path=log/job/1/ctest_all_ufo__spice_gnu_debug/01/job.out#2106

Testing has been conducted with one of the sith kgo runs to show the change does not affect results:
https://cylchub/services/cylc-review/taskjobs/michael.c.cooke?&suite=sith_ufo4112%2Fkgo_glu&cycles=20210701T1200Z