### PR TITLE
Improve cmake targets for code linters

### DIFF
--- a/CPPLINT.cfg
+++ b/CPPLINT.cfg
@@ -1,3 +1,3 @@
 set noparent
 linelength=100
-filter=+build,-build/include_alpha,-build/c++11,+legal,+readability,+runtime,+whitespace,-runtime/references
+filter=+build,-build/include_alpha,-build/c++11,+legal,+readability,+runtime,-runtime/references,+whitespace,-whitespace/indent_namespace

--- a/src/nemo-feedback/NemoFeedback.cc
+++ b/src/nemo-feedback/NemoFeedback.cc
@@ -10,6 +10,7 @@
 #include <bitset>
 #include <set>
 #include <string>
+#include <tuple>
 #include <utility>
 #include <vector>
 
@@ -214,7 +215,7 @@ void NemoFeedback::write_all_data(
     // Pull out QC flags from UFO
     feedback_io::Data<int32_t> variableQCFlagsData;
     if (obsdb_.has("QCFlags", ufo_name)) {
-      variableQCFlagsData = creator.create("QCFlags", ufo_name, int32_t(0));
+      variableQCFlagsData = creator.create("QCFlags", ufo_name, static_cast<int32_t>(0));
     } else {
       const size_t iv = flags_.varnames().find(ufo_name);
       std::vector<int32_t> variable_qcFlags;
@@ -396,7 +397,7 @@ NemoFeedback::setupIDs(const NemoFeedbackDataCreator& creator) const {
 
   if (obsdb_.has("MetaData", "buoyIdentifier")) {
     feedback_io::Data<std::string> buoyIDs(
-        creator.create("MetaData", "buoyIdentifier", int32_t(0), buoyIDWidth));
+        creator.create("MetaData", "buoyIdentifier", static_cast<int32_t>(0), buoyIDWidth));
     for (size_t iOb = 0; iOb < stationIDs.n_obs(); ++iOb) {
       if (stationIdentificationAvailable) {
         if (buoyIDs[iOb] != missingStringFeedback &&
@@ -421,7 +422,7 @@ NemoFeedback::setupIDs(const NemoFeedbackDataCreator& creator) const {
   constexpr size_t stationTypeWidth = 4;
   if (obsdb_.has("MetaData", "fdbk_station_type")) {
     stationTypes = feedback_io::Data<std::string>(creator.create(
-        "MetaData", "fdbk_station_type", int32_t(0), stationTypeWidth, true));
+        "MetaData", "fdbk_station_type", static_cast<int32_t>(0), stationTypeWidth, true));
   } else {
     std::vector<std::string> blankStationTypeData(obsdb_.nlocs(),
                                                   std::string(4, ' '));

--- a/src/nemo-feedback/NemoFeedbackDataCreator.cc
+++ b/src/nemo-feedback/NemoFeedbackDataCreator.cc
@@ -6,11 +6,13 @@
 
 #include <string.h>
 
-#include <tuple>
-#include <vector>
+#include <cstdio>
 #include <memory>
 #include <sstream>
+#include <string>
+#include <tuple>
 #include <utility>
+#include <vector>
 
 #include "eckit/exception/Exceptions.h"
 

--- a/src/nemo-feedback/feedback_io/Data.cc
+++ b/src/nemo-feedback/feedback_io/Data.cc
@@ -4,11 +4,12 @@
 
 
 #include <iostream>
-#include <sstream>
-#include <string>
 #include <memory>
 #include <numeric>
+#include <sstream>
+#include <string>
 #include <utility>
+#include <vector>
 
 #include "eckit/exception/Exceptions.h"
 

--- a/src/nemo-feedback/feedback_io/Utils.cc
+++ b/src/nemo-feedback/feedback_io/Utils.cc
@@ -8,9 +8,10 @@
 // https://github.com/Unidata/netcdf-cxx4
 
 #include <algorithm>
-#include <sstream>
-#include <iomanip>
 #include <cstring>
+#include <iomanip>
+#include <sstream>
+#include <string>
 
 #include "eckit/exception/Exceptions.h"
 

--- a/src/nemo-feedback/feedback_io/Writer.cc
+++ b/src/nemo-feedback/feedback_io/Writer.cc
@@ -9,9 +9,13 @@
 // https://github.com/Unidata/netcdf-cxx4
 
 #include <algorithm>
-#include <sstream>
-#include <iomanip>
 #include <cstring>
+#include <iomanip>
+#include <map>
+#include <memory>
+#include <sstream>
+#include <string>
+#include <vector>
 
 #include "eckit/exception/Exceptions.h"
 
@@ -179,7 +183,9 @@ void Writer<C>::write_metadata_variables(
       for (size_t j=0; j < STRINGNAM_NUM; ++j) {
         if (j < name_data_.variable_names[i].length()) {
           data[j] = static_cast<char>(name_data_.variable_names.at(i).at(j));
-        } else {data[j] = ' ';}
+        } else {
+          data[j] = ' ';
+        }
       }
       if (isExtraVariable[i]) {
         nc_var_list_extra.putVar({iextra++, 0}, {1, STRINGNAM_NUM}, data);
@@ -203,7 +209,9 @@ void Writer<C>::write_metadata_variables(
       for (size_t j=0; j < STRINGNAM_NUM; ++j) {
         if (j < name_data_.additional_names[i].length()) {
           data[j] = static_cast<char>(name_data_.additional_names.at(i).at(j));
-        } else {data[j] = ' ';}
+        } else {
+          data[j] = ' ';
+        }
       }
       nc_entries_var.putVar({i, 0}, {1, STRINGNAM_NUM}, data);
     }

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -6,10 +6,20 @@ add_subdirectory(Data)
 add_subdirectory(nemo-feedback)
 add_subdirectory(mains)
 
-ecbuild_add_test( TARGET test_nemo_feedback_coding_norms
-                  TYPE SCRIPT
-                  COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/../../tools/cpplint.py
-                  ARGS --recursive ${CMAKE_CURRENT_SOURCE_DIR}/../ )
+find_program(
+  CPPLINT_EXECUTABLE
+  NAMES cpplint
+  DOC "Path to the cpplint executable"
+)
+if( CPPLINT_EXECUTABLE )
+  ecbuild_add_test(
+    TARGET "${PROJECT_NAME}_coding_norms"
+    LABELS lint
+    TYPE SCRIPT
+    COMMAND "${CPPLINT_EXECUTABLE}"
+    ARGS --quiet --recursive "${CMAKE_CURRENT_SOURCE_DIR}/.."
+  )
+endif()
 
 ecbuild_add_test( TARGET test_nemo_feedback_hofx_ice_writer
                   OMP 1
@@ -20,7 +30,7 @@ ecbuild_add_test( TARGET test_nemo_feedback_hofx_ice_file
                   OMP 1
                   ARGS testoutput/test_hofx_sic_writer_out.nc testoutput/test_hofx_sic_writer_out_ref.cdl
                   COMMAND ./mains/compare_nc_cdl.sh
-                  TEST_DEPENDS test_nemo_feedback_hofx_ice_writer)
+                  TEST_DEPENDS test_nemo_feedback_hofx_ice_writer )
 
 ecbuild_add_test( TARGET test_nemo_feedback_hofx_two_vars_writer
                   OMP 1
@@ -31,7 +41,7 @@ ecbuild_add_test( TARGET test_nemo_feedback_hofx_two_vars_file
                   OMP 1
                   ARGS testoutput/test_hofx_two_vars_writer_out.nc testoutput/test_hofx_two_vars_writer_out_ref.cdl
                   COMMAND ./mains/compare_nc_cdl.sh
-                  TEST_DEPENDS test_nemo_feedback_hofx_two_vars_writer)
+                  TEST_DEPENDS test_nemo_feedback_hofx_two_vars_writer )
 
 ecbuild_add_test( TARGET test_nemo_feedback_hofx_profiles_writer
                   OMP 1
@@ -42,7 +52,7 @@ ecbuild_add_test( TARGET test_nemo_feedback_hofx_profiles_file
                   OMP 1
                   ARGS testoutput/test_hofx_profiles_writer_out.nc testoutput/test_hofx_profiles_writer_out_ref.cdl
                   COMMAND ./mains/compare_nc_cdl.sh
-                  TEST_DEPENDS test_nemo_feedback_hofx_profiles_writer)
+                  TEST_DEPENDS test_nemo_feedback_hofx_profiles_writer )
 
 ecbuild_add_test( TARGET test_nemo_feedback_hofx_profiles_two_vars_writer
                   OMP 1
@@ -53,7 +63,7 @@ ecbuild_add_test( TARGET test_nemo_feedback_hofx_profiles_two_vars_file
                   OMP 1
                   ARGS testoutput/test_hofx3d_nc_prof_2vars_writer_out.nc testoutput/test_hofx3d_nc_prof_2vars_writer_out_ref.cdl
                   COMMAND ./mains/compare_nc_cdl.sh
-                  TEST_DEPENDS test_nemo_feedback_hofx_profiles_two_vars_writer)
+                  TEST_DEPENDS test_nemo_feedback_hofx_profiles_two_vars_writer )
 
 ecbuild_add_test( TARGET test_nemo_feedback_hofx_mpi_2_writer
                   OMP 1
@@ -65,7 +75,7 @@ ecbuild_add_test( TARGET test_nemo_feedback_hofx_mpi_2_file
                   OMP 1
                   ARGS testoutput/test_hofx_mpi_2_writer_out_00001.nc testoutput/test_hofx_mpi_2_writer_out_00001_ref.cdl
                   COMMAND ./mains/compare_nc_cdl.sh
-                  TEST_DEPENDS test_nemo_feedback_hofx_mpi_2_writer)
+                  TEST_DEPENDS test_nemo_feedback_hofx_mpi_2_writer )
 
 ecbuild_add_test( TARGET test_nemo_feedback_hofx_mpi_3_writer
                   OMP 1
@@ -77,4 +87,4 @@ ecbuild_add_test( TARGET test_nemo_feedback_hofx_mpi_3_file
                   OMP 1
                   ARGS testoutput/test_hofx_mpi_3_writer_out_00001.nc testoutput/test_hofx_mpi_3_writer_out_00001_ref.cdl
                   COMMAND ./mains/compare_nc_cdl.sh
-                  TEST_DEPENDS test_nemo_feedback_hofx_mpi_3_writer)
+                  TEST_DEPENDS test_nemo_feedback_hofx_mpi_3_writer )

--- a/src/tests/nemo-feedback/test_feedback_data.cc
+++ b/src/tests/nemo-feedback/test_feedback_data.cc
@@ -2,11 +2,12 @@
  * (C) British Crown Copyright 2026 Met Office
  */
 
+#include <algorithm>
 #include <iostream>
 #include <memory>
-#include <string>
-#include <algorithm>
 #include <numeric>
+#include <string>
+#include <vector>
 
 #include "eckit/log/Bytes.h"
 

--- a/src/tests/nemo-feedback/test_feedback_writer.cc
+++ b/src/tests/nemo-feedback/test_feedback_writer.cc
@@ -2,15 +2,16 @@
  * (C) British Crown Copyright 2026 Met Office
  */
 
-#include<netcdf>
+#include <netcdf>
 
-#include<string>
-#include<chrono>
-#include<thread>
 #include <algorithm>
+#include <chrono>
+#include <iomanip>
 #include <numeric>
 #include <sstream>
-#include <iomanip>
+#include <string>
+#include <thread>
+#include <vector>
 
 #include "eckit/log/Bytes.h"
 


### PR DESCRIPTION
## Description

Modify cpplint target to use `cpplint` from the environment. ~Remove `cpplint.py` from source tree.~

cpplint 2.0.2 happiness:
- Fix build/include_what_you_use
- Update filter categories.

## Checklist

- [x] I have updated the unit tests to cover the change
- [x] New functions are documented briefly via Doxygen comments in the code _-na-_
- [x] I have linted my code using cpplint
- [ ] I have run the unit tests
- [ ] I have run mo-bundle to check integration with the rest of JEDI and run the unit tests under all environments
